### PR TITLE
Support for writing blog posts in Jupyter notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _build/
 *vscode*
 *pyc
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ Both of these services must pass before the PR will be merged, furthermore, one 
 ## Creating a Blog Post
 
 Blog posts can be added by creating a new text file in the _posts/<current year> directory.
-The filename must use the following naming convention `YEAR-MONTH-DAY-title.rst` and be written in [RST](http://www.sphinx-doc.org/en/stable/rest.html) formatted text.
-Each file must also contain the following header for Sphinx via [Ablog](https://github.com/sunpy/ablog) to parse the post properly:
+The filename must use the following naming convention `YEAR-MONTH-DAY-title.{ext}` and be written in one of the following formats:
+
+* [RST](http://www.sphinx-doc.org/en/stable/rest.html) formatted text, `ext=rst`,
+* [Jupyter notebook](http://jupyter.org/), `ext=ipynb`; (notebooks are converted to RST using the [nbsphinx](http://nbsphinx.readthedocs.io) extension)
+
+If you write your post in RST formatted text, each file must also contain the following header for Sphinx via [Ablog](https://github.com/sunpy/ablog) to parse the post properly:
 
 ```rst
 <Title>
@@ -56,6 +60,8 @@ Each file must also contain the following header for Sphinx via [Ablog](https://
    :tags: <Tag list with commas>
    :category: <One of the below>
 ```
+
+When writing posts as Jupyter notebooks, the first cell should be a Markdown cell with the title as a top level heading (i.e. using a single `#`) and the second cell should be a raw cell containing the post information listed above. See the [nbsphinx docs](http://nbsphinx.readthedocs.io/raw-cells.html) for information on making raw notebook cells compatible with Sphinx and RST.
 
 Please note that the date for the post is different to the way it is written for the blog filename.
 Since this date is reader facing, we want month day year **e.g.,** 14 May 2056.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Both of these services must pass before the PR will be merged, furthermore, one 
 
 ## Creating a Blog Post
 
-Blog posts can be added by creating a new text file in the _posts/<current year> directory.
+Blog posts can be added by creating a new text file in the `posts/<current year>` directory.
 The filename must use the following naming convention `YEAR-MONTH-DAY-title.{ext}` and be written in one of the following formats:
 
 * [RST](http://www.sphinx-doc.org/en/stable/rest.html) formatted text, `ext=rst`,

--- a/conf.py
+++ b/conf.py
@@ -6,7 +6,7 @@ import ablog
 from sunpy_sphinx_theme.conf import *
 
 sys.path.append(os.path.abspath('exts'))
-extensions = ['sphinx.ext.githubpages', 'ablog', 'sphinxcontrib.rawfiles', 'cards', 
+extensions = ['sphinx.ext.githubpages', 'ablog', 'sphinxcontrib.rawfiles', 'cards',
               'sphinx.ext.intersphinx', 'sphinx.ext.imgmath', 'nbsphinx']
 templates_path = [ablog.get_html_templates_path()]
 

--- a/conf.py
+++ b/conf.py
@@ -18,6 +18,8 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
 
 rawfiles = ['jitsi.html']
 
+imgmath_image_format = 'svg'
+
 disqus_shortname = 'sunpy-org'
 blog_baseurl = 'https://sunpy.org/blog.html'
 blog_feed_fulltext = True

--- a/conf.py
+++ b/conf.py
@@ -25,6 +25,7 @@ blog_feed_length = 10
 blog_feed_archives = True
 
 source_suffix = '.rst'
+exclude_patterns = ['posts/*/.ipynb_checkpoints/*']
 master_doc = 'index'
 project = u'SunPy'
 author = 'SunPy Project'

--- a/conf.py
+++ b/conf.py
@@ -6,7 +6,8 @@ import ablog
 from sunpy_sphinx_theme.conf import *
 
 sys.path.append(os.path.abspath('exts'))
-extensions = ['sphinx.ext.githubpages', 'ablog', 'sphinxcontrib.rawfiles', 'cards', 'sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.githubpages', 'ablog', 'sphinxcontrib.rawfiles', 'cards', 
+              'sphinx.ext.intersphinx', 'sphinx.ext.imgmath', 'nbsphinx']
 templates_path = [ablog.get_html_templates_path()]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ sphinx
 sphinxcontrib-rawfiles
 sunpy-sphinx-theme
 ablog
+nbsphinx
+ipython


### PR DESCRIPTION
Closes #130 

This adds the `nbsphinx` extension to the `conf.py` file (as well as the included `imgmath` extension for rendering equations). I added IPython as a dependency because it provides the needed code highlighting lexer to render the notebook code properly in RST