### PR TITLE
Add RST test blog post to try out use of front-matter instead of directives

### DIFF
--- a/posts/2020/2020-01-01_test_rst_ablog.rst
+++ b/posts/2020/2020-01-01_test_rst_ablog.rst
@@ -1,6 +1,5 @@
 :blog: True
 :author: Kris STern
-:post: 2020-10-01
 :tags: sunpy
 :category: Update
 

--- a/posts/2020/2020-01-01_test_rst_ablog.rst
+++ b/posts/2020/2020-01-01_test_rst_ablog.rst
@@ -1,0 +1,11 @@
+:blog: True
+:author: Kris STern
+:date: 2020-10-01
+:tags: sunpy
+:category: Update
+
+Test blog: SunPy constantly reinventing and improving itself
+============================================================
+
+Any comment, idea, suggestion, feedback, or well-grounded opinion is welcome for a reality check, which will help SunPy to keep constantly evolving and staying relevant despite the passage of time.
+We value diversity, and encourage contributions to the SunPy project for all who is interested in solar physics research.

--- a/posts/2020/2020-01-01_test_rst_ablog.rst
+++ b/posts/2020/2020-01-01_test_rst_ablog.rst
@@ -1,6 +1,6 @@
 :blog: True
 :author: Kris STern
-:date: 2020-10-01
+:post: 2020-10-01
 :tags: sunpy
 :category: Update
 

--- a/posts/2020/2020-01-01_test_rst_ablog.rst
+++ b/posts/2020/2020-01-01_test_rst_ablog.rst
@@ -1,4 +1,4 @@
-:blog: True
+:blogpost: true
 :author: Kris STern
 :tags: sunpy
 :category: Update


### PR DESCRIPTION
For **testing**. 

Have been experiencing issues with the ablog configuration for `markdown` when creating a test blog post in #253, so would like to test using simply front-matter with a `RST` test blog to see if this setup works for `RST` files. 