### PR TITLE
Update card formatting

### DIFF
--- a/exts/cards.py
+++ b/exts/cards.py
@@ -35,7 +35,7 @@ def visit_card_node(self, node):
 def depart_card_node(self, node):
     body = f"""
                                 <p>Affiliation: <a href="{node['aff_link']}">{node['aff_name']}</a></p>
-                                <p>Github: <a href="https://github.com/{node['github']}">{node['github']}</a></p>
+                                <p>GitHub: <a href="https://github.com/{node['github']}">{node['github']}</a></p>
                                 <p>Start Date: {node['date']}</p>
                             </div>
                             <div class="modal-footer">

--- a/exts/cards.py
+++ b/exts/cards.py
@@ -10,7 +10,7 @@ def visit_card_node(self, node):
     title = node.get("title", "")
     key = title or node["github"]
     key = key.lower().replace(" ", "-")
-    title = f"<h4>{title}</h4>"
+    title = f"<h4>{title}</h4>" if len(title) > 0 else ""
 
     col_extra_class = "column-half" if title else ""
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description
The board cards on the [project page](https://sunpy.org/project/) don't have a title, which still creates `<h4>` tags which has the effect of adding excess padding above the cards. This PR only adds the tag if the title is set. I've also changes `Github` to `GitHub` inside the "More Info" section of the card.

I'm also opening a PR on the theme repository to allow for three lines of title as the "Continuous Integration Maintainer" title is over three lines and overlaps with the box below.
<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->


