### PR TITLE
Add page for the 2022 coordination meeting

### DIFF
--- a/project/index.rst
+++ b/project/index.rst
@@ -11,6 +11,7 @@ SunPy Project
    roles
    affiliated
    former
+   meetings
 
 The **SunPy project** is the organization which maintains the SunPy library and sponsored affiliated packages.
 Its primary goal is to *facilitate and promote the use and development of a community-led, free and open-source solar data-analysis software based on the scientific Python environment*.

--- a/project/meetings.rst
+++ b/project/meetings.rst
@@ -1,22 +1,21 @@
-==========
+========
 Meetings
-==========
+========
 
 2022 SunPy Coordination Meeting
-================================
+*******************************
 
 The 2022 SunPy Coordination Meeting will take place 22-26 August, 2022.
-The meeting will be held virtually and in person at the Dublin Institute for Advanced Study (DIAS)
-in Dublin, IE.
+The meeting will be held virtually and in person at the Dublin Institute for Advanced Study (DIAS) in Dublin, Ireland.
 
 Registration
 ------------
 
-Please register your interest below prior to 1 July.
-Registration and attendance is free though in-person attendance wil be capped at 40 people due to space constraints.
+Please register your interest below prior to 1st July 2022.
+Registration and attendance is free, though in-person attendance will be capped at 40 people due to space constraints.
 
 .. raw:: html
-    
+
     <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfg16MlcVmi4iVF0UqarAMuR1jhHI5Goa48q3qfoXgzTBBntw/viewform?embedded=true" width="640" height="1057" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
 
 Agenda

--- a/project/meetings.rst
+++ b/project/meetings.rst
@@ -1,0 +1,35 @@
+==========
+Meetings
+==========
+
+2022 SunPy Coordination Meeting
+================================
+
+The 2022 SunPy Coordination Meeting will take place 22-26 August, 2022.
+The meeting will be held virtually and in person at the Dublin Institute for Advanced Study (DIAS)
+in Dublin, IE.
+
+Registration
+------------
+
+Please register your interest below prior to 1 July.
+Registration and attendance is free though in-person attendance wil be capped at 40 people due to space constraints.
+
+.. raw:: html
+    
+    <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfg16MlcVmi4iVF0UqarAMuR1jhHI5Goa48q3qfoXgzTBBntw/viewform?embedded=true" width="640" height="1057" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+
+Agenda
+-------
+
+A detailed agenda will be provided closer to the meeting.
+
+Virtual Participation
+---------------------
+
+Details regarding virtual participation will be posted here closer to the time of the meeting.
+
+Venue
+-----
+
+The meeting will be held in person at the `Dublin Institute for Advanced Studies <https://www.dias.ie/>`_.


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

This adds a page under the "Project" tab for the 2022 coordination meeting. I've added it under a general "meetings" heading as we may want to add information about future (or past) meetings here as well.

When I build locally, I do not see the "Meetings" title in the navbar dropdown. Would the theme have to be modified to include this? If so, I can add it in a different spot.

I've also embedded the google registration form into the page. If this is not desirable (I thought it was nice to just stick it all on one page) then I can switch it to a link.