### PR TITLE
Application for roentgen to become an affiliated package

### DIFF
--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -116,6 +116,22 @@ Affiliated Packages
    * - Version reviewed
      - `v0.5.2 <https://github.com/dstansby/pfsspy/releases/tag/0.5.2>`__
 
+.. list-table::
+   :widths: 20, 80
+
+   * - **roentgen**
+     - A Python package for the quantitative analysis of the interaction of energetic x-rays with matter.
+   * - Links
+     - `Documentation <https://roentgen.readthedocs.io>`__, `Source code <https://github.com/ehsteve/roentgen>`__
+   * - Maintainer(s)
+     - `Steven Christe`_, `Shane Maloney`_
+   * - Badges
+     - 
+   * - Version reviewed
+     - `v1.0.0 <https://github.com/ehsteve/roentgen/releases/tag/v1.0>`__
+
+
+
 Provisional Affiliated Packages
 -------------------------------
 
@@ -156,6 +172,7 @@ Provisional Affiliated Packages
 .. _Mark Cheung: https://github.com/fluxtransport
 .. _Nabil Freij: https://github.com/nabobalis
 .. _Shane Maloney: https://github.com/samaloney
+.. _Steven Christe: https://github.com/ehsteve
 
 Affiliated Package Review
 -------------------------


### PR DESCRIPTION
## Affiliated Package Application for roentgen

This PR is for the [roentgen](https://github.com/ehsteve/roentgen) package to become an affiliated package. `roentgen` is a Python package for the quantitative analysis of the interaction of energetic x-rays with matter. This package is named after one of the discoverers of X-rays, [Wilhelm Röntgen](https://en.wikipedia.org/wiki/Wilhelm_Röntgen). Though it is not specific to solar physics it is used by solar physics missions such as [Solar Orbiter STIX](https://datacenter.stix.i4ds.net). The future solar x-ray mission, PADRE, will also use it. Given its wide utility, it would be beneficial for this package to be under the umbrella of an organization.

If possible, I would ask that this package be moved under the sunpy organization (similar to `radiospectra`. I did not consider to apply for the sponsored affiliated package since this package does not extensively make use of sunpy functionality as it does not need it.
