### PR TITLE
Improve affiliated package layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = SunPy
 SOURCEDIR     = .

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -107,7 +107,7 @@ These packages are works in progress that do not yet meet the functionality crit
    * - **pyflct**
      - A Python wrapper for Fourier Local Correlation Tracking. `Documentation <https://pyflct.readthedocs.io/>`__, `Source code <https://github.com/sunpy/pyflct>`__
 
-       **Maintainers**: `Nabil Freij`_, `Stuart Mumford`_
+       **Maintainers**: `The SunPy Project`_
 
        |package_specialized| |integration_none| |docs_some| |tests_excellent| |duplication_none| |community_good| |dev_low|
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -102,7 +102,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
 Provisional packages
 --------------------
-These packages are works in progress that don't yet meet the functionality crieteria for an affiliated package, but is working towards it.
+These packages are works in progress that do not yet meet the functionality criteria for an affiliated package, but are working towards it.
 
 
 .. list-table::

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -25,7 +25,7 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
-       *Maintainer*: The SunPy Community
+       **Maintainer**: The SunPy Community
 
        Version reviewed: `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
 
@@ -79,7 +79,7 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        `Documentation <https://docs.sunpy.org/projects/sunkit-image/>`__, `Source code <https://github.com/sunpy/sunkit-image/>`__
 
-       Maintainer: `Nabil Freij`_, `Stuart Mumford`_
+       **Maintainers**: `Nabil Freij`_, `Stuart Mumford`_
 
        |package_general| |integration_partial| |docs_good| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
 
@@ -96,7 +96,7 @@ Affiliated Packages
 
        `Documentation <https://aiapy.readthedocs.io/en/latest/>`__, `Source code <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy>`__
 
-       Maintainers: `Will Barnes`_, `Mark Cheung`_, `Nabil Freij`_
+       **Maintainers**: `Will Barnes`_, `Mark Cheung`_, `Nabil Freij`_
 
        |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_good| |dev_stc|
 
@@ -110,7 +110,7 @@ Affiliated Packages
 
        `Documentation <https://pfsspy.readthedocs.io/>`__, `Source code <https://github.com/dstansby/pfsspy/>`__
 
-       Maintainers: `David Stansby`_
+       **Maintainer**: `David Stansby`_
 
        |package_specialized| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -24,12 +24,12 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        Version reviewed: `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
 
-   * - **NDCube**
+   * - **ndcube**
      - A base package for multi-dimensional (non)contiguous coordinate-aware arrays.
 
        `Documentation <https://docs.sunpy.org/projects/ndcube>`__, `Source code <https://github.com/sunpy/ndcube>`__
 
-       *Maintainers*: The SunPy Community
+       **Maintainers**: The SunPy Community
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -10,11 +10,6 @@ What is an affiliated package?
 Affiliated packages are well-maintained, open source software packages that are useful to solar physicists and integrate well with the SunPy ecosystem.
 To aid discoverability, all affiliated packages are listed on the SunPy website, and the SunPy project tries to advertise them at national and international conferences and workshops.
 
-Sponsored Packages
-------------------
-
-A SunPy sponsored package is an affiliated package that is maintained and governed by the SunPy project.
-
 .. list-table::
    :widths: 20, 80
 
@@ -34,7 +29,7 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        `Documentation <https://docs.sunpy.org/projects/ndcube>`__, `Source code <https://github.com/sunpy/ndcube>`__
 
-       *Maintainers*: `Daniel Ryan`_, `Stuart Mumford`_
+       *Maintainers*: The SunPy Community
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
@@ -45,7 +40,7 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        `Documentation <https://docs.sunpy.org/projects/drms>`__, `Source code <https://github.com/sunpy/drms>`__
 
-       **Maintainers**: `Kolja Glogowski`_, `Will Barnes`_, `Nabil Freij`_
+       **Maintainers**: The SunPy Community
 
        |package_general| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stable|
 
@@ -56,7 +51,7 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        `Documentation <https://docs.sunpy.org/projects/sunraster/en/latest/>`__, `Source code <https://github.com/sunpy/sunraster>`__
 
-       **Maintainers**: `Daniel Ryan`_, `Nabil Freij`_
+       **Maintainers**: The SunPy Community
 
        |package_specialized| |integration_full| |docs_some| |tests_good| |duplication_none| |community_excellent| |dev_stc|
 
@@ -67,17 +62,11 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        `Documentation <https://docs.sunpy.org/projects/sunkit-image/>`__, `Source code <https://github.com/sunpy/sunkit-image/>`__
 
-       **Maintainers**: `Nabil Freij`_, `Stuart Mumford`_
+       **Maintainers**: The SunPy Community
 
        |package_general| |integration_partial| |docs_good| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
 
        Version reviewed: `v0.1 <https://github.com/sunpy/sunkit-image/releases/tag/v0.1.0>`__
-
-Affiliated Packages
--------------------
-
-.. list-table::
-   :widths: 20, 80
 
    * - **aiapy**
      - aiapy is a Python package for analyzing data from the Atmospheric Imaging Assembly (AIA) instrument onboard NASA's Solar Dynamics Observatory spacecraft.

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -29,9 +29,6 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        Version reviewed: `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
 
-.. list-table::
-   :widths: 20, 80
-
    * - **NDCube**
      - A base package for multi-dimensional (non)contiguous coordinate-aware arrays.
 
@@ -42,9 +39,6 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
        Version reviewed: `v1.3.2 <https://github.com/sunpy/ndcube/releases/tag/v1.3.2>`__
-
-.. list-table::
-   :widths: 20, 80
 
    * - **drms**
      - Provides search capability for the JSOC DRMS server which enables complex queries of HMI, AIA and MDI data.
@@ -57,9 +51,6 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
 
        Version reviewed: `v0.5.7 <https://github.com/sunpy/drms/releases/tag/v0.5.7>`__
 
-.. list-table::
-   :widths: 20, 80
-
    * - **sunraster**
      - sunraster is a package designed for reading, manipulating and visualizing data taken with slit spectrograph instruments.
 
@@ -70,9 +61,6 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
        |package_specialized| |integration_full| |docs_some| |tests_good| |duplication_none| |community_excellent| |dev_stc|
 
        Version reviewed: `v0.1.2 <https://github.com/sunpy/sunraster/releases/tag/v0.1.2>`__
-
-.. list-table::
-   :widths: 20, 80
 
    * - **sunkit-image**
      - An open-source toolbox for solar physics image processing. Currently it is an experimental library for various solar physics specific image processing routines.
@@ -101,9 +89,6 @@ Affiliated Packages
        |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_good| |dev_stc|
 
        Version reviewed: `v0.1.0 <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy/-/releases/v0.1.0>`__
-
-.. list-table::
-   :widths: 20, 80
 
    * - **pfsspy**
      - A Python Potential Field Source Surface model package.

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -100,6 +100,33 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 .. _Nabil Freij: https://github.com/nabobalis
 .. _Shane Maloney: https://github.com/samaloney
 
+Provisional packages
+--------------------
+These packages are works in progress that don't yet meet the functionality crieteria for an affiliated package, but is working towards it.
+
+
+.. list-table::
+   :widths: 20, 80
+
+   * - **pyflct**
+     - A Python wrapper for Fourier Local Correlation Tracking. `Documentation <https://pyflct.readthedocs.io/>`__, `Source code <https://github.com/sunpy/pyflct>`__
+
+       **Maintainers**: `Nabil Freij`_, `Stuart Mumford`_
+
+       |package_specialized| |integration_none| |docs_some| |tests_excellent| |duplication_none| |community_good| |dev_low|
+
+       Version reviewed: `v0.2.1 <https://github.com/sunpy/pyflct/releases/tag/v0.2.1>`__
+
+   * - **radiospectra**
+     - This package provides support for some types of solar radio spectrograms (e.g. CALISTO, SWAVES). `Documentation <https://docs.sunpy.org/projects/radiospectra>`__, `Source code <https://github.com/sunpy/radiospectra>`__
+
+       **Maintainers**: `David Pérez-Suárez`_, `Shane Maloney`_, `Nabil Freij`_,
+
+       |package_general| |integration_none| |docs_some| |tests_good| |duplication_some| |community_excellent| |dev_stc|
+
+       Version reviewed: `v0.3.0 <https://github.com/sunpy/radiospectra/releases/tag/v0.3.0>`__
+
+
 Affiliated Package Review
 -------------------------
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -1,8 +1,8 @@
 :tocdepth: 3
 
-=========================
-SunPy Affiliated Packages
-=========================
+===================
+Affiliated Packages
+===================
 
 Affiliated packages are well-maintained, open source software packages that are useful to solar physicists and integrate well with the SunPy ecosystem.
 To aid discoverability, all affiliated packages are listed on the SunPy website, and the SunPy project tries to advertise them at national and international conferences and workshops.
@@ -17,7 +17,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
-       **Maintainer**: The SunPy Project
+       **Maintainer**: `The SunPy Project`_
 
        Version reviewed: `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
 
@@ -26,7 +26,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/ndcube>`__, `Source code <https://github.com/sunpy/ndcube>`__
 
-       **Maintainers**: The SunPy Project
+       **Maintainers**: `The SunPy Project`_
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
@@ -37,7 +37,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/drms>`__, `Source code <https://github.com/sunpy/drms>`__
 
-       **Maintainers**: The SunPy Project
+       **Maintainers**: `The SunPy Project`_
 
        |package_general| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stable|
 
@@ -48,7 +48,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/sunraster/en/latest/>`__, `Source code <https://github.com/sunpy/sunraster>`__
 
-       **Maintainers**: The SunPy Project
+       **Maintainers**: `The SunPy Project`_
 
        |package_specialized| |integration_full| |docs_some| |tests_good| |duplication_none| |community_excellent| |dev_stc|
 
@@ -59,7 +59,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/sunkit-image/>`__, `Source code <https://github.com/sunpy/sunkit-image/>`__
 
-       **Maintainers**: The SunPy Project
+       **Maintainers**: `The SunPy Project`_
 
        |package_general| |integration_partial| |docs_good| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
 
@@ -89,12 +89,12 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
 .. _Daniel Ryan: https://github.com/danryanirish
 .. _David Pérez-Suárez: https://github.com/dpshelio
-.. _Kolja Glogowski: https://github.com/kbg
 .. _Stuart Mumford: https://github.com/Cadair
 .. _David Stansby: https://github.com/dstansby
 .. _Will Barnes: https://github.com/wtbarnes
 .. _Nabil Freij: https://github.com/nabobalis
 .. _Shane Maloney: https://github.com/samaloney
+.. _The SunPy Project: https://sunpy.org/project/#community-roles
 
 Provisional packages
 --------------------
@@ -116,7 +116,7 @@ These packages are works in progress that do not yet meet the functionality crit
    * - **radiospectra**
      - This package provides support for some types of solar radio spectrograms (e.g. CALISTO, SWAVES). `Documentation <https://docs.sunpy.org/projects/radiospectra>`__, `Source code <https://github.com/sunpy/radiospectra>`__
 
-       **Maintainers**: `David Pérez-Suárez`_, `Shane Maloney`_, `Nabil Freij`_,
+       **Maintainers**: `The SunPy Project`_
 
        |package_general| |integration_none| |docs_some| |tests_good| |duplication_some| |community_excellent| |dev_stc|
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -70,7 +70,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://aiapy.readthedocs.io/en/latest/>`__, `Source code <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy>`__
 
-       **Maintainers**: `Will Barnes`_, `Mark Cheung`_, `Nabil Freij`_
+       **Maintainers**: `Will Barnes`_, `Nabil Freij`_
 
        |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_good| |dev_stc|
 
@@ -93,7 +93,6 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 .. _Stuart Mumford: https://github.com/Cadair
 .. _David Stansby: https://github.com/dstansby
 .. _Will Barnes: https://github.com/wtbarnes
-.. _Mark Cheung: https://github.com/fluxtransport
 .. _Nabil Freij: https://github.com/nabobalis
 .. _Shane Maloney: https://github.com/samaloney
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -4,9 +4,6 @@
 SunPy Affiliated Packages
 =========================
 
-What is an affiliated package?
-------------------------------
-
 Affiliated packages are well-maintained, open source software packages that are useful to solar physicists and integrate well with the SunPy ecosystem.
 To aid discoverability, all affiliated packages are listed on the SunPy website, and the SunPy project tries to advertise them at national and international conferences and workshops.
 
@@ -20,7 +17,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
-       **Maintainer**: The SunPy Community
+       **Maintainer**: The SunPy Project
 
        Version reviewed: `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
 
@@ -29,7 +26,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/ndcube>`__, `Source code <https://github.com/sunpy/ndcube>`__
 
-       **Maintainers**: The SunPy Community
+       **Maintainers**: The SunPy Project
 
        |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
 
@@ -40,7 +37,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/drms>`__, `Source code <https://github.com/sunpy/drms>`__
 
-       **Maintainers**: The SunPy Community
+       **Maintainers**: The SunPy Project
 
        |package_general| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stable|
 
@@ -51,7 +48,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/sunraster/en/latest/>`__, `Source code <https://github.com/sunpy/sunraster>`__
 
-       **Maintainers**: The SunPy Community
+       **Maintainers**: The SunPy Project
 
        |package_specialized| |integration_full| |docs_some| |tests_good| |duplication_none| |community_excellent| |dev_stc|
 
@@ -62,7 +59,7 @@ To aid discoverability, all affiliated packages are listed on the SunPy website,
 
        `Documentation <https://docs.sunpy.org/projects/sunkit-image/>`__, `Source code <https://github.com/sunpy/sunkit-image/>`__
 
-       **Maintainers**: The SunPy Community
+       **Maintainers**: The SunPy Project
 
        |package_general| |integration_partial| |docs_good| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
 

--- a/project/affiliated.rst
+++ b/project/affiliated.rst
@@ -19,61 +19,71 @@ A SunPy sponsored package is an affiliated package that is maintained and govern
    :widths: 20, 80
 
    * - **sunpy core**
-     - A core package for solar physics in Python. `Documentation <https://docs.sunpy.org/>`__, `Source code <https://github.com/sunpy/sunpy>`__
-   * - Maintainer(s)
-     - The SunPy Community
-   * - Badges
-     - |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
-   * - Version reviewed
-     - `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
+     - A core package for solar physics in Python.
+
+       `Documentation <https://docs.sunpy.org/>`__, `Source code <https://github.com/sunpy/sunpy>`__
+
+       |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
+
+       *Maintainer*: The SunPy Community
+
+       Version reviewed: `v1.1.4 <https://github.com/sunpy/sunpy/releases/tag/v1.1.4>`__
 
 .. list-table::
    :widths: 20, 80
 
    * - **NDCube**
-     - A base package for multi-dimensional (non)contiguous coordinate-aware arrays. `Documentation <https://docs.sunpy.org/projects/ndcube>`__, `Source code <https://github.com/sunpy/ndcube>`__
-   * - Maintainer(s)
-     - `Daniel Ryan`_, `Stuart Mumford`_
-   * - Badges
-     - |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
-   * - Version reviewed
-     - `v1.3.2 <https://github.com/sunpy/ndcube/releases/tag/v1.3.2>`__
+     - A base package for multi-dimensional (non)contiguous coordinate-aware arrays.
+
+       `Documentation <https://docs.sunpy.org/projects/ndcube>`__, `Source code <https://github.com/sunpy/ndcube>`__
+
+       *Maintainers*: `Daniel Ryan`_, `Stuart Mumford`_
+
+       |package_general| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stable|
+
+       Version reviewed: `v1.3.2 <https://github.com/sunpy/ndcube/releases/tag/v1.3.2>`__
 
 .. list-table::
    :widths: 20, 80
 
    * - **drms**
-     - Provides search capability for the JSOC DRMS server which enables complex queries of HMI, AIA and MDI data. `Documentation <https://docs.sunpy.org/projects/drms>`__, `Source code <https://github.com/sunpy/drms>`__
-   * - Maintainer(s)
-     - `Kolja Glogowski`_, `Will Barnes`_, `Nabil Freij`_
-   * - Badges
-     - |package_general| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stable|
-   * - Version reviewed
-     - `v0.5.7 <https://github.com/sunpy/drms/releases/tag/v0.5.7>`__
+     - Provides search capability for the JSOC DRMS server which enables complex queries of HMI, AIA and MDI data.
+
+       `Documentation <https://docs.sunpy.org/projects/drms>`__, `Source code <https://github.com/sunpy/drms>`__
+
+       **Maintainers**: `Kolja Glogowski`_, `Will Barnes`_, `Nabil Freij`_
+
+       |package_general| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stable|
+
+       Version reviewed: `v0.5.7 <https://github.com/sunpy/drms/releases/tag/v0.5.7>`__
 
 .. list-table::
    :widths: 20, 80
 
    * - **sunraster**
-     - sunraster is a package designed for reading, manipulating and visualizing data taken with slit spectrograph instruments. `Documentation <https://docs.sunpy.org/projects/sunraster/en/latest/>`__, `Source code <https://github.com/sunpy/sunraster>`__
-   * - Maintainer(s)
-     - `Daniel Ryan`_, `Nabil Freij`_
-   * - Badges
-     - |package_specialized| |integration_full| |docs_some| |tests_good| |duplication_none| |community_excellent| |dev_stc|
-   * - Version reviewed
-     - `v0.1.2 <https://github.com/sunpy/sunraster/releases/tag/v0.1.2>`__
+     - sunraster is a package designed for reading, manipulating and visualizing data taken with slit spectrograph instruments.
+
+       `Documentation <https://docs.sunpy.org/projects/sunraster/en/latest/>`__, `Source code <https://github.com/sunpy/sunraster>`__
+
+       **Maintainers**: `Daniel Ryan`_, `Nabil Freij`_
+
+       |package_specialized| |integration_full| |docs_some| |tests_good| |duplication_none| |community_excellent| |dev_stc|
+
+       Version reviewed: `v0.1.2 <https://github.com/sunpy/sunraster/releases/tag/v0.1.2>`__
 
 .. list-table::
    :widths: 20, 80
 
    * - **sunkit-image**
-     - An open-source toolbox for solar physics image processing. Currently it is an experimental library for various solar physics specific image processing routines. `Documentation <https://docs.sunpy.org/projects/sunkit-image/>`__, `Source code <https://github.com/sunpy/sunkit-image/>`__
-   * - Maintainer(s)
-     - `Nabil Freij`_, `Stuart Mumford`_
-   * - Badges
-     - |package_general| |integration_partial| |docs_good| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
-   * - Version reviewed
-     - `v0.1 <https://github.com/sunpy/sunkit-image/releases/tag/v0.1.0>`__
+     - An open-source toolbox for solar physics image processing. Currently it is an experimental library for various solar physics specific image processing routines.
+
+       `Documentation <https://docs.sunpy.org/projects/sunkit-image/>`__, `Source code <https://github.com/sunpy/sunkit-image/>`__
+
+       Maintainer: `Nabil Freij`_, `Stuart Mumford`_
+
+       |package_general| |integration_partial| |docs_good| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
+
+       Version reviewed: `v0.1 <https://github.com/sunpy/sunkit-image/releases/tag/v0.1.0>`__
 
 Affiliated Packages
 -------------------
@@ -82,52 +92,29 @@ Affiliated Packages
    :widths: 20, 80
 
    * - **aiapy**
-     - aiapy is a Python package for analyzing data from the Atmospheric Imaging Assembly (AIA) instrument onboard NASA's Solar Dynamics Observatory spacecraft. `Documentation <https://aiapy.readthedocs.io/en/latest/>`__, `Source code <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy>`__
-   * - Maintainer(s)
-     -  `Will Barnes`_, `Mark Cheung`_, `Nabil Freij`_
-   * - Badges
-     - |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_good| |dev_stc|
-   * - Version reviewed
-     - `v0.1.0 <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy/-/releases/v0.1.0>`__
+     - aiapy is a Python package for analyzing data from the Atmospheric Imaging Assembly (AIA) instrument onboard NASA's Solar Dynamics Observatory spacecraft.
+
+       `Documentation <https://aiapy.readthedocs.io/en/latest/>`__, `Source code <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy>`__
+
+       Maintainers: `Will Barnes`_, `Mark Cheung`_, `Nabil Freij`_
+
+       |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_good| |dev_stc|
+
+       Version reviewed: `v0.1.0 <https://gitlab.com/LMSAL_HUB/aia_hub/aiapy/-/releases/v0.1.0>`__
 
 .. list-table::
    :widths: 20, 80
 
    * - **pfsspy**
-     - A Python Potential Field Source Surface model package. `Documentation <https://pfsspy.readthedocs.io/>`__, `Source code <https://github.com/dstansby/pfsspy/>`__
-   * - Maintainer(s)
-     - `David Stansby`_
-   * - Badges
-     - |package_specialized| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
-   * - Version reviewed
-     - `v0.5.2 <https://github.com/dstansby/pfsspy/releases/tag/0.5.2>`__
+     - A Python Potential Field Source Surface model package.
 
-Provisional Affiliated Packages
--------------------------------
+       `Documentation <https://pfsspy.readthedocs.io/>`__, `Source code <https://github.com/dstansby/pfsspy/>`__
 
-.. list-table::
-   :widths: 20, 80
+       Maintainers: `David Stansby`_
 
-   * - **pyflct**
-     - A Python wrapper for Fourier Local Correlation Tracking. `Documentation <https://pyflct.readthedocs.io/>`__, `Source code <https://github.com/sunpy/pyflct>`__
-   * - Maintainer(s)
-     - `Nabil Freij`_, `Stuart Mumford`_
-   * - Badges
-     - |package_specialized| |integration_none| |docs_some| |tests_excellent| |duplication_none| |community_good| |dev_low|
-   * - Version reviewed
-     - `v0.2.1 <https://github.com/sunpy/pyflct/releases/tag/v0.2.1>`__
+       |package_specialized| |integration_full| |docs_extensive| |tests_excellent| |duplication_none| |community_excellent| |dev_stc|
 
-.. list-table::
-   :widths: 20, 80
-
-   * - **radiospectra**
-     - This package provides support for some types of solar radio spectrograms (e.g. CALISTO, SWAVES). `Documentation <https://docs.sunpy.org/projects/radiospectra>`__, `Source code <https://github.com/sunpy/radiospectra>`__
-   * - Maintainer(s)
-     - `David Pérez-Suárez`_, `Shane Maloney`_, `Nabil Freij`_,
-   * - Badges
-     - |package_general| |integration_none| |docs_some| |tests_good| |duplication_some| |community_excellent| |dev_stc|
-   * - Version reviewed
-     - `v0.3.0 <https://github.com/sunpy/radiospectra/releases/tag/v0.3.0>`__
+       Version reviewed: `v0.5.2 <https://github.com/dstansby/pfsspy/releases/tag/0.5.2>`__
 
 .. _Daniel Ryan: https://github.com/danryanirish
 .. _David Pérez-Suárez: https://github.com/dpshelio


### PR DESCRIPTION
This improves the layout of the affiliated package page, to compress it all horizontally a bit, and make sure the LH column contains just a list of packages. This makes it much easier to scan down the list.

I also got rid of provisional affiliated packages, as there isn't really such a thing as "provisional", and packages should go through the review process to be listed on the website.