### PR TITLE
Fix "Version reviewed" of solarmach (3.3.0 -> 0.3.3)

### DIFF
--- a/affiliated.rst
+++ b/affiliated.rst
@@ -152,7 +152,7 @@ Package list
 
        |package_general| |integration_partial| |docs_good| |tests_good| |duplication_none| |community_excellent| |dev_stc|
 
-       Version reviewed: `v3.3.0 <https://github.com/jgieseler/solarmach/releases/tag/v0.3.3>`__
+       Version reviewed: `v0.3.3 <https://github.com/jgieseler/solarmach/releases/tag/v0.3.3>`__
 
 
 .. _Steven Christe: https://github.com/ehsteve


### PR DESCRIPTION
Fix for small typo in https://github.com/sunpy/sunpy.org/issues/381: "Version reviewed" of solarmach should be 0.3.3 instead of 3.3.0

