### PR TITLE
Fix eclipse blog ouput

### DIFF
--- a/posts/2024/2024-04-03-eclipse.ipynb
+++ b/posts/2024/2024-04-03-eclipse.ipynb
@@ -7,7 +7,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    ".. post:: 5 April 2024\n",
+    ".. post:: 3 April 2024\n",
     "   :author: Stuart Mumford\n",
     "   :tags: eclipse, outreach, tutorials\n",
     "   :category: Tutorial\n",

--- a/posts/2024/2024-04-03-eclipse.ipynb
+++ b/posts/2024/2024-04-03-eclipse.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "b77eac75-539b-42db-91d7-302978bf764c",
    "metadata": {},
    "outputs": [],
@@ -448,7 +448,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eclipse_map"
+    "eclipse_map.plot()"
    ]
   },
   {
@@ -491,7 +491,7 @@
    "metadata": {},
    "source": [
     "We can then plot the expected location of Regulus on our eclipse image.\n",
-    "We set the scaling such that it make Regulus more visible.\n",
+    "We set the scaling such that it make Regulus more visible and zoom in on the relevant part of the field of view.\n",
     "You can see that the expected location and the actual location are quite different."
    ]
   },
@@ -504,12 +504,14 @@
    "source": [
     "fig = plt.figure(figsize=(9,9))\n",
     "ax = plt.subplot(projection=eclipse_map)\n",
-    "eclipse_map.plot(axes=ax, vmax=20)\n",
+    "eclipse_map.plot(axes=ax, clip_interval=(0,90)*u.percent)\n",
     "ax.plot_coord(regulus, 'o', markeredgewidth=0.5, markeredgecolor='w',\n",
     "              markerfacecolor='None', markersize=10, label='Regulus')\n",
     "eclipse_map.draw_grid(axes=ax)\n",
     "eclipse_map.draw_limb(axes=ax)\n",
     "plt.legend()\n",
+    "plt.xlim(100,500)\n",
+    "plt.ylim(0,500)\n",
     "plt.show()"
    ]
   },
@@ -685,12 +687,14 @@
    "source": [
     "fig = plt.figure(figsize=(9,9))\n",
     "ax = plt.subplot(projection=eclipse_map)\n",
-    "eclipse_map.plot(axes=ax, vmax=20)\n",
+    "eclipse_map.plot(axes=ax, clip_interval=(0,90)*u.percent)\n",
     "ax.plot_coord(regulus, 'o', markeredgewidth=0.5, markeredgecolor='w',\n",
     "              markerfacecolor='None', markersize=10, label='Regulus')\n",
     "eclipse_map.draw_grid(axes=ax)\n",
     "eclipse_map.draw_limb(axes=ax)\n",
     "plt.legend()\n",
+    "plt.xlim(100,500)\n",
+    "plt.ylim(0,500)\n",
     "plt.show()"
    ]
   },
@@ -800,7 +804,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The eclipse blog post wasn't rendering properly. This PR fixes the output and also crops several the images showing the alignment with Regulus to better show how rotating the image improves the alignment.