### PR TITLE
Add xrtpy and irispy-lmsal to the affiliated package page

### DIFF
--- a/affiliated.rst
+++ b/affiliated.rst
@@ -170,7 +170,7 @@ Current packages
 
        `Documentation <https://irispy-lmsal.readthedocs.io>`__, `Source code <https://github.com/LM-SAL/irispy-lmsal>`__
 
-       **Maintainer**: `Nabil Freij`_
+       **Maintainer**: `IRIS Team @ LMSAL`_
 
        |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stc|
 
@@ -182,9 +182,9 @@ Current packages
 .. _Stuart Mumford: https://github.com/Cadair
 .. _David Stansby: https://github.com/dstansby
 .. _Will Barnes: https://github.com/wtbarnes
-.. _Nabil Freij: https://github.com/nabobalis
 .. _Shane Maloney: https://github.com/samaloney
 .. _The SunPy Project: https://sunpy.org/about/roles
+.. _IRIS Team @ LMSAL: https://iris.lmsal.com/
 .. _Jan Gieseler: https://github.com/jgieseler
 .. _Joy Velasquez: https://github.com/joyvelasquez
 .. _Nick Murphy: https://github.com/namurphy

--- a/affiliated.rst
+++ b/affiliated.rst
@@ -154,6 +154,16 @@ Current packages
 
        Version reviewed: `v1.0.0 <https://github.com/sunpy/sunkit-magex/releases/tag/v1.0.0>`__
 
+   * - **xrtpy**
+     - XRTpy facilitates the analysis of observations from the X-Ray Telescope (XRT) aboard the Hinode spacecraft.
+
+       `Documentation <https://xrtpy.readthedocs.io>`__, `Source code <https://github.com/HinodeXRT/xrtpy>`__
+
+       **Maintainer**: `Joy Velasquez`_, `Nick Murphy`_, `Jonathan Slavin`_
+
+       |package_specialized| |integration_full| |docs_good| |tests_good| |duplication_none| |community_good| |dev_stc|
+
+       Version reviewed: `v0.4.1 <https://github.com/HinodeXRT/xrtpy/releases/tag/v0.4.1>`__
 
 .. _Steven Christe: https://github.com/ehsteve
 .. _Daniel Ryan: https://github.com/danryanirish
@@ -165,6 +175,9 @@ Current packages
 .. _Shane Maloney: https://github.com/samaloney
 .. _The SunPy Project: https://sunpy.org/about/roles
 .. _Jan Gieseler: https://github.com/jgieseler
+.. _Joy Velasquez: https://github.com/joyvelasquez
+.. _Nick Murphy: https://github.com/namurphy
+.. _Jonathan Slavin: https://github.com/jslavin
 
 Provisional packages
 --------------------

--- a/affiliated.rst
+++ b/affiliated.rst
@@ -71,7 +71,7 @@ Current packages
 
        `Documentation <https://aiapy.readthedocs.io/en/stable/>`__, `Source code <https://github.com/LM-SAL/aiapy>`__
 
-       **Maintainers**: `Will Barnes`_, `Nabil Freij`_
+       **Maintainers**: `Will Barnes`_, `AIA Team @ LMSAL`_
 
        |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_good| |dev_stc|
 
@@ -185,6 +185,7 @@ Current packages
 .. _Shane Maloney: https://github.com/samaloney
 .. _The SunPy Project: https://sunpy.org/about/roles
 .. _IRIS Team @ LMSAL: https://iris.lmsal.com/
+.. _AIA Team @ LMSAL: https://aia.lmsal.com/
 .. _Jan Gieseler: https://github.com/jgieseler
 .. _Joy Velasquez: https://github.com/joyvelasquez
 .. _Nick Murphy: https://github.com/namurphy

--- a/affiliated.rst
+++ b/affiliated.rst
@@ -165,6 +165,17 @@ Current packages
 
        Version reviewed: `v0.4.1 <https://github.com/HinodeXRT/xrtpy/releases/tag/v0.4.1>`__
 
+   * - **irispy-lmsal**
+     - A Python package that provides the tools to read in and analyze data from the IRIS solar-observing satellite.
+
+       `Documentation <https://irispy-lmsal.readthedocs.io>`__, `Source code <https://github.com/LM-SAL/irispy-lmsal>`__
+
+       **Maintainer**: `Nabil Freij`_
+
+       |package_specialized| |integration_full| |docs_extensive| |tests_good| |duplication_none| |community_excellent| |dev_stc|
+
+       Version reviewed: `v0.2.0 <https://github.com/LM-SAL/irispy-lmsal/releases/tag/v0.2.0>`__
+
 .. _Steven Christe: https://github.com/ehsteve
 .. _Daniel Ryan: https://github.com/danryanirish
 .. _David Pérez-Suárez: https://github.com/dpshelio


### PR DESCRIPTION
Fixes #431 
Fixes #414 

Should also add `xrtpy` do the docs dropdown, but I believe this involves modifying the theme.