### PR TITLE
Update website for NumFOCUS coc

### DIFF
--- a/coc_old.md
+++ b/coc_old.md
@@ -1,0 +1,47 @@
+(coc_old)=
+
+# Previous SunPy Project Code of Conduct
+
+A member of SunPy is:
+
+## Open
+
+Members of the community are open to collaboration, whether on patches, reporting issues, asking for help or otherwise.
+We welcome those interested in joining the community, and realise that including people with a variety of opinions and backgrounds will only serve to enrich our community.
+
+We are accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference, ensuring that all participants are heard and feel confident that they can freely express their opinions.
+
+## Considerate
+
+Members of the community are considerate of their peers -- other developers, users, etc.
+We are thoughtful when addressing the efforts of others, keeping in mind that often the labour was completed simply for the good of the community.
+We are attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+
+We recognize the work made by everyone and ensure the proper acknowledgement/citation of original authors at all times.
+As authors, we pledge to be explicit about how we want our own work to be cited or acknowledged.
+
+## Respectful
+
+Members of the community are respectful.
+We are respectful of others, their positions, their skills, their commitments, and their efforts.
+We are respectful of the volunteer and professional efforts within the community.
+We are respectful of the processes set forth in the community, and we work within them (paying particular attention to those new to the community).
+
+When we disagree, we are courteous in raising our issues.
+We provide a harassment- and bullying-free environment, regardless of sex, sexual orientation, gender identity, disability, physical appearance, body size, race, nationality, ethnicity, and religion.
+In particular, sexual language and imagery, sexist, racist, or otherwise exclusionary jokes are not appropriate.
+We will treat those outside our community with the same respect as people within our community.
+
+Overall, we are good to each other and apply this code of conduct to all community situations online and offline, including mailing lists, forums, social media, conferences, meetings, associated social events, and one-to-one interactions.
+
+We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct.
+We will take action when members of our community violate this code such as contacting <confidential@sunpy.org> (all emails sent to this address will be treated with the strictest confidence) or talking privately with the person.
+
+Parts of this code of conduct have been adapted from the [astropy](https://www.astropy.org/code_of_conduct.html) and the [Python Software Foundation](https://www.python.org/psf/conduct/) codes of conduct.
+
+---
+
+## License
+
+The SunPy Community Code of Conduct is licensed under a Creative Commons Attribution 4.0 International License.
+We encourage other communities related to ours to use or adapt this code as they see fit.

--- a/coc_old.md
+++ b/coc_old.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 (coc_old)=
 
 # Previous SunPy Project Code of Conduct


### PR DESCRIPTION
This PR modifies the website to reflect the changes needed if SunPy adopts the NumFOCUS Code of Conduct. The canonical source for the code of conduct is in the `.github` repo, see this PR: https://github.com/sunpy/.github/pull/34

Discussions on if we should adopt the NumFOCUS code of conduct should take place on Discourse: https://community.openastronomy.org/t/proposal-to-adopt-the-numfocus-code-of-conduct-for-sunpy/1408